### PR TITLE
Fix `hud_select_item_m`: inventory text item not displayed

### DIFF
--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -612,6 +612,7 @@ namespace openre::hud
                 sort_itembox();
                 snd_se_on(0x4060000);
             }
+
             break;
         }
         case ITEM_BOX_STATE_SELECT_BOX:
@@ -753,8 +754,10 @@ namespace openre::hud
         }
         }
 
-        const auto& item = gGameTable.inventory[gGameTable.inventory_cursor];
+        const auto cursor = gGameTable.inventory_cursor;
+        const auto& item = gGameTable.inventory[cursor];
         hud_render_selection(item.Part);
+        hud_render_inventory_text(16, 175, 6, item.Type);
     }
 
     static const Action _itemBoxRender[] = {


### PR DESCRIPTION
## Description

Using itembox, the inventory item text is not rendered. It seems that bug was introduced in #29 

## Bug sample

![bug](https://github.com/user-attachments/assets/544401b6-12a5-4967-8bb0-a88356393447)

## Fix
![fixed](https://github.com/user-attachments/assets/dbbed79d-16e5-4b61-8572-5f92d47a1aa0)
