### PR TITLE
Implement `hud_inventory_mix _item`

### DIFF
--- a/address_map.txt
+++ b/address_map.txt
@@ -510,6 +510,9 @@ declare     _st                     u8                      0x00691F61
 declare     itembox_state           u8                      0x00691F62
 declare     byte_691F63             u8                      0x00691F63
 declare     byte_691F64             u8                      0x00691F64
+declare     byte_691F65             u8                      0x00691F65
+declare     byte_691F66             u8                      0x00691F66
+declare     byte_691F67             u8                      0x00691F67
 declare     byte_691F68             u8                      0x00691F68
 declare     byte_691F69             u8                      0x00691F69
 declare     byte_691F6A             u8                      0x00691F6A
@@ -520,6 +523,14 @@ declare     byte_691F6F             u8                      0x00691F6F
 declare     byte_691F70             u8                      0x00691F70
 declare     byte_691F74             u8                      0x00691F74
 declare     byte_691F76             u8                      0x00691F76
+declare     byte_691F7C             u8                      0x00691F7C
+declare     byte_691F7D             u8                      0x00691F7D
+declare     byte_691F7E             u8                      0x00691F7E
+declare     byte_691F7F             u8                      0x00691F7F
+declare     byte_691F80             u8                      0x00691F80
+declare     byte_691F81             u8                      0x00691F81
+declare     byte_691F82             u8                      0x00691F82
+declare     byte_691F83             u8                      0x00691F83
 declare     itembox_slot_id         u8                      0x00691F84
 declare     byte_691F85             u8                      0x00691F85
 declare     byte_691F86             u8                      0x00691F86

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -1056,7 +1056,7 @@ namespace openre::hud
                 }
             }
             // Mix items
-            if (check_input(KEY_TYPE_ACTION))
+            if (check_input(KEY_TYPE_4096))
             {
                 gGameTable.byte_691F64 = hud_check_item_mix();
                 if (gGameTable.byte_691F64)

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -1220,7 +1220,7 @@ namespace openre::hud
             auto auxRedQuantity = greenItem.Quantity;
             redItem.Quantity = greenItem.Quantity;
             greenItem.Quantity = auxRedQuantity;
-            if (!redItem.Quantity)
+            if (redItem.Quantity == 0)
             {
                 set_inventory_item(redCursor, 0, 0, 0);
             }

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -41,6 +41,29 @@ namespace openre::hud
         INVENTORY_ITEM_HIDE_COMMAND_BOX,
     };
 
+    enum
+    {
+        INVENTORY_MIX_ITEM_MOVE_GREEN_CURSOR,
+        INVENTORY_MIX_ITEM_STACK_CURSORS,
+        INVENTORY_MIX_ITEM_2,
+        INVENTORY_MIX_ITEM_3,
+        INVENTORY_MIX_ITEM_4,
+        INVENTORY_MIX_ITEM_WEAPON_TO_AMMO,
+        INVENTORY_MIX_ITEM_AMMO_TO_WEAPON,
+        INVENTORY_MIX_ITEM_7,
+        INVENTORY_MIX_ITEM_8,
+        INVENTORY_MIX_ITEM_9,
+        INVENTORY_MIX_ITEM_10,
+        INVENTORY_MIX_ITEM_CONFIRM_MESSAGE,
+    };
+
+    constexpr uint8_t INVENTORY_INFINITE_QUANTITY = 0xFF;
+
+    constexpr uint8_t INVENTORY_SPECIAL_ITEM_SLOT = 10;
+
+    constexpr uint32_t MESSAGE_KIND_ALREADY_FULLY_LOADED = 2;
+    constexpr uint32_t MESSAGE_KIND_WILL_YOU_MIX_ITEMS = 11;
+
     using Action = void (*)();
 
     static Action* gHudImplTable = (Action*)0x5402C0;
@@ -849,10 +872,451 @@ namespace openre::hud
         interop::call<void, int>(0x004FF1C0, a0);
     }
 
+    // 0x004FE7C0
+    static int st_disp_cursol1(int a0)
+    {
+        return interop::call<int, int>(0x004FE7C0, a0);
+    }
+
+    // 0x00502B30
+    static void check_cursol_distance(int a0)
+    {
+        interop::call<int>(0x00502B30, a0);
+    }
+
+    // 0x005024D0
+    static int set_inventory_item(int slotId, int type, int quantity, int part)
+    {
+        gGameTable.inventory[slotId].Type = type;
+        gGameTable.inventory[slotId].Quantity = quantity;
+        gGameTable.inventory[slotId].Part = part;
+        return slotId;
+    }
+
+    // 0x00502500
+    static void set_inventory_item_quantity(int slotId, int quantity)
+    {
+        auto part = gGameTable.inventory[slotId].Part;
+        if (part == 1)
+        {
+            gGameTable.inventory[slotId + 1].Quantity = quantity;
+        }
+        gGameTable.inventory[slotId].Quantity = quantity;
+        if (part == 2)
+        {
+            if (slotId == 0)
+            {
+                gGameTable.item_twork.Quantity = quantity;
+            }
+            else
+            {
+                gGameTable.inventory[slotId - 1].Quantity = quantity;
+            }
+        }
+    }
+
     // 0x004F88B0
     static void hud_inventory_mix_item()
     {
-        interop::call(0x004F88B0);
+        auto& redCursor = gGameTable.inventory_cursor;
+        auto& greenCursor = gGameTable.inventory_cursor_2;
+        auto& redItem = gGameTable.inventory[redCursor];
+        auto& greenItem = gGameTable.inventory[greenCursor];
+        const auto inventorySize = gGameTable.inventory_size;
+        const auto mixQuantity = redItem.Quantity + greenItem.Quantity;
+
+        gGameTable.byte_691F76 = 0;
+        switch (gGameTable.byte_691F64)
+        {
+        case INVENTORY_MIX_ITEM_MOVE_GREEN_CURSOR:
+        {
+            auto oldGreenCursor = greenCursor;
+
+            if (gGameTable.fg_system & 0x80000000)
+            {
+                // Right
+                if (gGameTable.word_9885FC & 0x2000 && greenCursor < inventorySize - 1)
+                {
+                    if (greenItem.Part == 1)
+                    {
+                        greenCursor++;
+                    }
+                    greenCursor++;
+                }
+                // Left
+                if (gGameTable.word_9885FC & 0x8000 && greenCursor && greenCursor != INVENTORY_SPECIAL_ITEM_SLOT)
+                {
+                    auto auxGreenCursor = greenCursor;
+                    if (greenItem.Part == 2)
+                    {
+                        if (greenCursor == 1)
+                        {
+                            auxGreenCursor = 2;
+                        }
+                        else
+                        {
+                            auxGreenCursor--;
+                        }
+                    }
+                    greenCursor = --auxGreenCursor;
+                }
+                // Down
+                if (gGameTable.word_9885FC & 0x4000)
+                {
+                    if (greenCursor >= inventorySize - 2)
+                    {
+                        if (greenCursor == INVENTORY_SPECIAL_ITEM_SLOT)
+                        {
+                            greenCursor = 1;
+                        }
+                    }
+                    else
+                    {
+                        greenCursor += 2;
+                    }
+                }
+                // Up
+                if (gGameTable.word_9885FC & 0x1000 && greenCursor != INVENTORY_SPECIAL_ITEM_SLOT)
+                {
+                    if (greenCursor <= 1)
+                    {
+                        greenCursor = INVENTORY_SPECIAL_ITEM_SLOT;
+                    }
+                    else
+                    {
+                        greenCursor -= 2;
+                    }
+                }
+                if (oldGreenCursor != greenCursor)
+                {
+                    snd_se_on(0x4040000);
+                }
+            }
+            // Mix items
+            if (gGameTable.key_trg & 0x1000)
+            {
+                gGameTable.byte_691F64 = hud_check_item_mix();
+                if (gGameTable.byte_691F64)
+                {
+                    snd_se_on(0x4060000);
+                }
+                else
+                {
+                    snd_se_on(0x4070000);
+                }
+            }
+            // Cancel mix
+            if (gGameTable.key_trg & 0x2000)
+            {
+                snd_se_on(0x4050000);
+                gGameTable.itembox_state = 1;
+                gGameTable.byte_691F63 = 0;
+                gGameTable.byte_691F64 = 0;
+            }
+            st_disp_cursol1(gGameTable.inventory[greenCursor].Part);
+            hud_render_inventory_text(16, 175, 2, gGameTable.inventory[greenCursor].Type);
+            break;
+        }
+        case INVENTORY_MIX_ITEM_STACK_CURSORS:
+        {
+            if (gGameTable.byte_691F65++ < 10)
+            {
+                gGameTable.byte_691F7E += gGameTable.byte_691F7C;
+                gGameTable.byte_691F7F += gGameTable.byte_691F7D;
+                gGameTable.byte_691F82 += gGameTable.byte_691F80;
+                gGameTable.byte_691F83 += gGameTable.byte_691F81;
+                st_disp_cursol1(greenItem.Part);
+            }
+            else
+            {
+                if (gGameTable.byte_691F66)
+                {
+                    redCursor = greenCursor;
+                }
+                gGameTable.byte_691F7C = 0;
+                gGameTable.byte_691F7D = 0;
+                gGameTable.byte_691F7E = 0;
+                gGameTable.byte_691F7F = 0;
+                gGameTable.byte_691F80 = 0;
+                gGameTable.byte_691F81 = 0;
+                gGameTable.byte_691F82 = 0;
+                gGameTable.byte_691F83 = 0;
+                gGameTable.byte_691F64++;
+                gGameTable.byte_691F65 = 0;
+                gGameTable.byte_691F66 = 0;
+            }
+            break;
+        }
+        case INVENTORY_MIX_ITEM_2:
+        {
+            if (++gGameTable.byte_691F65 >= 4)
+            {
+                auto slotId = static_cast<uint8_t>(search_item(ITEM_TYPE_NONE));
+                if (slotId > 8 || slotId >= inventorySize - search_item(1))
+                {
+                    gGameTable.itembox_state = 4;
+                    gGameTable.byte_691F66 = 0;
+                    gGameTable.byte_691F65 = 0;
+                    gGameTable.byte_691F64 = 0;
+                    gGameTable.byte_691F63 = 0;
+                    break;
+                }
+                else
+                {
+                    gGameTable.inventory[slotId].Type = gGameTable.inventory[slotId + 1].Type;
+                    gGameTable.inventory[slotId].Quantity = gGameTable.inventory[slotId + 1].Quantity;
+                    gGameTable.inventory[slotId].Part = gGameTable.inventory[slotId + 1].Part;
+                    gGameTable.byte_691F65 = 0;
+                    if (gGameTable.byte_691F68 == slotId + 1)
+                    {
+                        gGameTable.byte_691F68--;
+                    }
+                    set_inventory_item(slotId + 1, 0, 0, 0);
+                }
+            }
+
+            if (gGameTable.byte_691F66)
+            {
+                gGameTable.itembox_state = 4;
+                gGameTable.byte_691F66 = 0;
+                gGameTable.byte_691F65 = 0;
+                gGameTable.byte_691F64 = 0;
+                gGameTable.byte_691F63 = 0;
+            }
+            break;
+        }
+        case INVENTORY_MIX_ITEM_3:
+        {
+            if (!(gGameTable.byte_691F65++))
+            {
+                show_message(0xAF0010, 0xE400, MESSAGE_KIND_ALREADY_FULLY_LOADED, 0);
+            }
+            else
+            {
+                if (gGameTable.fg_message >= 0)
+                {
+                    gGameTable.byte_691F65 = 0;
+                    gGameTable.byte_691F64 = 0;
+                    gGameTable.byte_691F63 = 0;
+                    gGameTable.itembox_state = 0;
+                }
+            }
+            break;
+        }
+        case INVENTORY_MIX_ITEM_4:
+        {
+            redItem.Type = gGameTable.byte_691F86;
+            redItem.Quantity = gGameTable.item_def_tbl[gGameTable.byte_691F86].max;
+            if (redCursor == gGameTable.byte_691F68)
+            {
+                gGameTable.byte_691F6A = gGameTable.byte_691F86;
+            }
+            if (greenCursor == gGameTable.byte_691F68)
+            {
+                gGameTable.byte_691F68 = redCursor;
+                gGameTable.byte_691F6A = gGameTable.byte_691F86;
+            }
+            set_inventory_item(greenCursor, 0, 0, 0);
+            gGameTable.byte_691F64 = 1;
+            gGameTable.byte_691F65 = 0;
+            gGameTable.byte_691F66 = 0;
+            check_cursol_distance(0);
+            break;
+        }
+        case INVENTORY_MIX_ITEM_WEAPON_TO_AMMO:
+        {
+            auto itemDef = gGameTable.item_def_tbl[redItem.Type];
+
+            if (redItem.Quantity == itemDef.max && redItem.Type < ITEM_TYPE_AMMO_HANDGUN)
+            {
+                gGameTable.byte_691F64 = 3;
+                gGameTable.byte_691F65 = 0;
+            }
+            else
+            {
+                if (redItem.Type != ITEM_TYPE_SUB_MACHINE_GUN || redItem.Quantity != INVENTORY_INFINITE_QUANTITY)
+                {
+                    if (itemDef.max < mixQuantity)
+                    {
+                        set_inventory_item_quantity(redCursor, itemDef.max);
+                        greenItem.Quantity = mixQuantity - itemDef.max;
+                    }
+                    else
+                    {
+                        set_inventory_item_quantity(redCursor, mixQuantity);
+                        set_inventory_item(greenCursor, 0, 0, 0);
+                    }
+
+                    gGameTable.byte_691F64 = 1;
+                    gGameTable.byte_691F65 = 0;
+                    gGameTable.byte_691F66 = 0;
+                    check_cursol_distance(0);
+                    break;
+                }
+                gGameTable.byte_691F64 = 0;
+                gGameTable.byte_691F65 = 0;
+            }
+            break;
+        }
+        case INVENTORY_MIX_ITEM_AMMO_TO_WEAPON:
+        {
+            auto itemDef = gGameTable.item_def_tbl[greenItem.Type];
+
+            if (greenItem.Quantity < itemDef.max || greenItem.Type >= ITEM_TYPE_AMMO_HANDGUN)
+            {
+                if (greenItem.Type == ITEM_TYPE_SUB_MACHINE_GUN && greenItem.Quantity == INVENTORY_INFINITE_QUANTITY)
+                {
+                    gGameTable.byte_691F64 = 3;
+                    gGameTable.byte_691F65 = 0;
+                }
+                else
+                {
+                    if (itemDef.max < mixQuantity)
+                    {
+                        set_inventory_item_quantity(greenCursor, itemDef.max);
+                        redItem.Quantity = mixQuantity - itemDef.max;
+                    }
+                    else
+                    {
+                        set_inventory_item_quantity(greenCursor, mixQuantity);
+                        set_inventory_item(redCursor, 0, 0, 0);
+                    }
+                    gGameTable.byte_691F64 = 1;
+                    gGameTable.byte_691F65 = 0;
+                    gGameTable.byte_691F66 = 1;
+                    check_cursol_distance(1);
+                }
+            }
+            else
+            {
+                gGameTable.byte_691F64 = 3;
+                gGameTable.byte_691F65 = 0;
+            }
+            break;
+        }
+        case INVENTORY_MIX_ITEM_7:
+        {
+            auto auxRedType = redItem.Type;
+            redItem.Type = greenItem.Type - 15;
+            if (gGameTable.byte_691F68 == redCursor)
+            {
+                gGameTable.byte_691F6A = redItem.Type;
+            }
+            greenItem.Type = auxRedType + 15;
+            auto auxRedQuantity = redItem.Quantity;
+            redItem.Quantity = greenItem.Quantity;
+            greenItem.Quantity = auxRedQuantity;
+            break;
+        }
+        case INVENTORY_MIX_ITEM_8:
+        {
+            auto auxGreenType = greenItem.Type;
+            greenItem.Type = redItem.Type - 15;
+            if (gGameTable.byte_691F6A == greenCursor)
+            {
+                gGameTable.byte_691F6A = greenItem.Type;
+            }
+            redItem.Type = auxGreenType + 15;
+            auto auxRedQuantity = greenItem.Quantity;
+            redItem.Quantity = greenItem.Quantity;
+            greenItem.Quantity = auxRedQuantity;
+            if (!redItem.Quantity)
+            {
+                set_inventory_item(redCursor, 0, 0, 0);
+            }
+            gGameTable.byte_691F64 = 1;
+            gGameTable.byte_691F65 = 0;
+            gGameTable.byte_691F66 = 0;
+            check_cursol_distance(1);
+            break;
+        }
+        // Demo or beta ?
+        case INVENTORY_MIX_ITEM_9:
+        {
+            auto type = greenItem.Type;
+            if (greenItem.Type == ITEM_TYPE_ANTI_VIRUS_BOMB)
+            {
+                type = ITEM_TYPE_AMMO_FLAME_ROUNDS;
+            }
+            if (greenItem.Type == 37) // Chemical ?
+            {
+                type = ITEM_TYPE_AMMO_SMG;
+            }
+            if (redItem.Quantity > 6)
+            {
+                redItem.Quantity -= 6;
+                greenItem.Type = type;
+                greenItem.Quantity = 6;
+            }
+            else
+            {
+                redItem.Type = type;
+                set_inventory_item(greenCursor, 0, 0, 0);
+            }
+            check_cursol_distance(0);
+            gGameTable.byte_691F64 = 1;
+            gGameTable.byte_691F65 = 0;
+            gGameTable.byte_691F66 = 0;
+            break;
+        }
+        // Demo or beta ?
+        case INVENTORY_MIX_ITEM_10:
+        {
+            auto type = redItem.Type;
+            if (redItem.Type == ITEM_TYPE_ANTI_VIRUS_BOMB)
+            {
+                type = ITEM_TYPE_AMMO_FLAME_ROUNDS;
+            }
+            if (redItem.Type == 37) // Chemical ?
+            {
+                type = ITEM_TYPE_AMMO_SMG;
+            }
+            if (redItem.Quantity > 6)
+            {
+                greenItem.Quantity -= 6;
+                redItem.Type = type;
+                redItem.Quantity = 6;
+            }
+            else
+            {
+                greenItem.Type = type;
+                set_inventory_item(redCursor, 0, 0, 0);
+            }
+            gGameTable.byte_691F64 = 1;
+            gGameTable.byte_691F65 = 0;
+            gGameTable.byte_691F66 = 0;
+            check_cursol_distance(0);
+            break;
+        }
+        case INVENTORY_MIX_ITEM_CONFIRM_MESSAGE:
+        {
+            if (gGameTable.byte_691F65)
+            {
+                if (gGameTable.fg_message >= 0)
+                {
+                    // Cancel mix
+                    if (gGameTable.fg_message & 1)
+                    {
+                        gGameTable.byte_691F64 = 0;
+                        gGameTable.byte_691F65 = 0;
+                        gGameTable.byte_691F66 = 0;
+                    }
+                    // Accept mix
+                    else
+                    {
+                        gGameTable.byte_691F64 = 4;
+                    }
+                }
+            }
+            else
+            {
+                show_message(0xAF0010, 0xE400, MESSAGE_KIND_WILL_YOU_MIX_ITEMS, 0);
+                gGameTable.byte_691F65++;
+            }
+            st_disp_cursol1(greenItem.Part);
+            break;
+        }
+        }
     }
 
     // 0x004F9260
@@ -1171,6 +1635,8 @@ namespace openre::hud
         interop::writeJmp(0x004C4AB0, &hud_fade_off);
         interop::writeJmp(0x004FC5B0, &exchange_item);
         interop::writeJmp(0x00502590, &hud_check_item_mix);
+        interop::writeJmp(0x005024D0, &set_inventory_item);
+        interop::writeJmp(0x00502500, &set_inventory_item_quantity);
         interop::writeJmp(0x004F8000, &hud_render_inventory);
     }
 }

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -1054,7 +1054,7 @@ namespace openre::hud
                 auto slotId = static_cast<uint8_t>(search_item(ITEM_TYPE_NONE));
                 if (slotId > 8 || slotId >= inventorySize - search_item(1))
                 {
-                    gGameTable.itembox_state = 4;
+                    gGameTable.itembox_state = ITEM_BOX_STATE_EXCHANGE;
                     gGameTable.byte_691F66 = 0;
                     gGameTable.byte_691F65 = 0;
                     gGameTable.byte_691F64 = 0;

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -1098,7 +1098,7 @@ namespace openre::hud
                     gGameTable.byte_691F65 = 0;
                     gGameTable.byte_691F64 = 0;
                     gGameTable.byte_691F63 = 0;
-                    gGameTable.itembox_state = 0;
+                    gGameTable.itembox_state = ITEM_BOX_STATE_SELECT_INVENTORY;
                 }
             }
             break;

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -1,6 +1,7 @@
 #include "hud.h"
 #include "audio.h"
 #include "file.h"
+#include "input.h"
 #include "interop.hpp"
 #include "item.h"
 #include "itembox.h"
@@ -11,6 +12,7 @@ using namespace openre::audio;
 using namespace openre::file;
 using namespace openre::itembox;
 using namespace openre::player;
+using namespace openre::input;
 
 namespace openre::hud
 {
@@ -932,7 +934,7 @@ namespace openre::hud
         {
             auto oldGreenCursor = greenCursor;
 
-            if (gGameTable.fg_system & 0x80000000)
+            if (check_flag(FlagGroup::System, FG_SYSTEM_0))
             {
                 // Right
                 if (gGameTable.word_9885FC & 0x2000 && greenCursor < inventorySize - 1)
@@ -993,7 +995,7 @@ namespace openre::hud
                 }
             }
             // Mix items
-            if (gGameTable.key_trg & 0x1000)
+            if (check_input(KEY_TYPE_ACTION))
             {
                 gGameTable.byte_691F64 = hud_check_item_mix();
                 if (gGameTable.byte_691F64)
@@ -1006,10 +1008,10 @@ namespace openre::hud
                 }
             }
             // Cancel mix
-            if (gGameTable.key_trg & 0x2000)
+            if (check_input(KEY_TYPE_RUN_AND_CANCEL))
             {
                 snd_se_on(0x4050000);
-                gGameTable.itembox_state = 1;
+                gGameTable.itembox_state = ITEM_BOX_STATE_SELECT_BOX;
                 gGameTable.byte_691F63 = 0;
                 gGameTable.byte_691F64 = 0;
             }
@@ -1077,7 +1079,7 @@ namespace openre::hud
 
             if (gGameTable.byte_691F66)
             {
-                gGameTable.itembox_state = 4;
+                gGameTable.itembox_state = ITEM_BOX_STATE_EXCHANGE;
                 gGameTable.byte_691F66 = 0;
                 gGameTable.byte_691F65 = 0;
                 gGameTable.byte_691F64 = 0;

--- a/src/input.h
+++ b/src/input.h
@@ -26,10 +26,10 @@ namespace openre::input
         KEY_TYPE_LEFT = 2,
         KEY_TYPE_RIGHT = 8,
         KEY_TYPE_ROTATE = 10,
-        KEY_TYPE_ACTION = 128,
+        KEY_TYPE_128 = 128,
         KEY_TYPE_AIM = 256,
         KEY_TYPE_RUN_AND_CANCEL = 512,
-        KEY_TYPE_ACTION = 4096,
+        KEY_TYPE_4096 = 4096,
     };
 
     [[nodiscard]] int GetGamepadState();

--- a/src/input.h
+++ b/src/input.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "openre.h"
+
 namespace openre::input
 {
     enum InputKey
@@ -27,8 +29,15 @@ namespace openre::input
         KEY_TYPE_128 = 128,
         KEY_TYPE_AIM = 256,
         KEY_TYPE_RUN_AND_CANCEL = 512,
+        KEY_TYPE_ACTION = 4096,
     };
 
     [[nodiscard]] int GetGamepadState();
+
+    [[nodiscard]] inline bool check_input(int key)
+    {
+        return gGameTable.key_trg & key;
+    }
+
     void input_init_hooks();
 };

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -660,7 +660,7 @@ namespace openre::player
                 set_routine(Routine::QUICKTURN);
                 return;
             }
-            if ((key_trg & input::KEY_TYPE_ACTION) != 0)
+            if ((key_trg & input::KEY_TYPE_128) != 0)
             {
                 set_flag(FlagGroup::Status, FG_STATUS_INTERACT, true);
             }
@@ -758,7 +758,7 @@ namespace openre::player
         {
             set_routine(Routine::PUSH_OBJECT);
         }
-        if ((key & input::KEY_TYPE_ACTION) == 0 && (key_trg & input::KEY_TYPE_ACTION) == 0)
+        if ((key & input::KEY_TYPE_128) == 0 && (key_trg & input::KEY_TYPE_128) == 0)
         {
             goto LABEL_31;
         }
@@ -769,7 +769,7 @@ namespace openre::player
         }
         if (oma_pl_updown_ck(player->id + 4) == 0)
         {
-            if (key_trg & input::KEY_TYPE_ACTION)
+            if (key_trg & input::KEY_TYPE_128)
             {
                 set_flag(FlagGroup::Status, FG_STATUS_INTERACT, true);
             }
@@ -796,7 +796,7 @@ namespace openre::player
         {
             set_routine(Routine::FORWARD);
         }
-        if (((key & input::KEY_TYPE_ACTION) == 0) && ((key_trg & input::KEY_TYPE_ACTION) == 0))
+        if (((key & input::KEY_TYPE_128) == 0) && ((key_trg & input::KEY_TYPE_128) == 0))
         {
             goto LABEL_25;
         }
@@ -806,7 +806,7 @@ namespace openre::player
         }
         if (oma_pl_updown_ck(player->id + 4) == 0)
         {
-            if (key_trg & input::KEY_TYPE_ACTION)
+            if (key_trg & input::KEY_TYPE_128)
             {
                 set_flag(FlagGroup::Status, FG_STATUS_INTERACT, true);
             }
@@ -844,7 +844,7 @@ namespace openre::player
         {
             player->cdir.y -= yAxisRotationSpeed[player->d_life_u];
         }
-        if (key & input::KEY_TYPE_ACTION || key_trg & input::KEY_TYPE_ACTION)
+        if (key & input::KEY_TYPE_128 || key_trg & input::KEY_TYPE_128)
         {
             if (player->Sca_info & 0x100000)
             {
@@ -855,7 +855,7 @@ namespace openre::player
             {
                 return;
             }
-            if (key_trg & input::KEY_TYPE_ACTION)
+            if (key_trg & input::KEY_TYPE_128)
             {
                 set_flag(FlagGroup::Status, FG_STATUS_INTERACT, true);
             }
@@ -891,7 +891,7 @@ namespace openre::player
         {
             set_routine(Routine::ROTATE);
         }
-        if (key_trg & input::KEY_TYPE_ACTION)
+        if (key_trg & input::KEY_TYPE_128)
         {
             set_flag(FlagGroup::Status, FG_STATUS_INTERACT, true);
             if (player->Sca_info & 0x100000)
@@ -1179,7 +1179,7 @@ namespace openre::player
                     player->cdir.y -= yAxisRotationSpeed[player->d_life_u];
                 }
             }
-            if (key & input::KEY_TYPE_ACTION || key_trg & input::KEY_TYPE_ACTION)
+            if (key & input::KEY_TYPE_128 || key_trg & input::KEY_TYPE_128)
             {
                 if (player->Sca_info & 0x100000)
                 {
@@ -1190,7 +1190,7 @@ namespace openre::player
                 {
                     return;
                 }
-                if (key_trg & input::KEY_TYPE_ACTION)
+                if (key_trg & input::KEY_TYPE_128)
                 {
                     set_flag(FlagGroup::Status, FG_STATUS_INTERACT, true);
                 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -252,31 +252,6 @@ namespace openre::player
         loc_4FC3FD();
     }
 
-    // 0x005024D0
-    static int set_inventory_item(int slotId, int type, int quantity, int part)
-    {
-        gGameTable.inventory[slotId].Type = type;
-        gGameTable.inventory[slotId].Quantity = quantity;
-        gGameTable.inventory[slotId].Part = part;
-        return slotId;
-    }
-
-    // 0x00502500
-    static void set_inventory_item_quantity(int slotId, int quantity)
-    {
-        gGameTable.inventory[slotId].Quantity = quantity;
-
-        auto part = gGameTable.inventory[slotId].Part;
-        if (part == 1)
-        {
-            gGameTable.inventory[slotId + 1].Quantity = quantity;
-        }
-        if (part == 2)
-        {
-            gGameTable.inventory[slotId].Quantity = quantity;
-        }
-    }
-
     // 0x004DABC0
     static int pl_neck(int a1, int a2)
     {
@@ -962,8 +937,6 @@ namespace openre::player
         interop::writeJmp(0x00502190, &partner_switch);
         interop::writeJmp(0x00502660, &inventory_find_item);
         interop::writeJmp(0x4FC3CE, itembox_prev_slot);
-        interop::writeJmp(0x5024D0, set_inventory_item);
-        interop::writeJmp(0x502500, set_inventory_item_quantity);
         interop::writeJmp(0x4D97B0, player_move);
         interop::writeJmp(0x4D9D20, pl_move);
         interop::writeJmp(0x4DC130, pl_mv_damage);

--- a/src/re2.h
+++ b/src/re2.h
@@ -670,7 +670,9 @@ struct GameTable
     uint8_t itembox_state;              // 0x691F62
     uint8_t byte_691F63;                // 0x691F63
     uint8_t byte_691F64;                // 0x691F64
-    uint8_t pad_691F65[3];              // 0x691F65
+    uint8_t byte_691F65;                // 0x691F65
+    uint8_t byte_691F66;                // 0x691F66
+    uint8_t byte_691F67;                // 0x691F67
     uint8_t byte_691F68;                // 0x691F68
     uint8_t byte_691F69;                // 0x691F69
     uint8_t byte_691F6A;                // 0x691F6A
@@ -684,7 +686,15 @@ struct GameTable
     uint8_t byte_691F74;                // 0x691F74
     uint8_t pad_691F75[1];              // 0x691F75
     uint8_t byte_691F76;                // 0x691F76
-    uint8_t pad_691F77[13];             // 0x691F77
+    uint8_t pad_691F77[5];              // 0x691F77
+    uint8_t byte_691F7C;                // 0x691F7C
+    uint8_t byte_691F7D;                // 0x691F7D
+    uint8_t byte_691F7E;                // 0x691F7E
+    uint8_t byte_691F7F;                // 0x691F7F
+    uint8_t byte_691F80;                // 0x691F80
+    uint8_t byte_691F81;                // 0x691F81
+    uint8_t byte_691F82;                // 0x691F82
+    uint8_t byte_691F83;                // 0x691F83
     uint8_t itembox_slot_id;            // 0x691F84
     uint8_t byte_691F85;                // 0x691F85
     uint8_t byte_691F86;                // 0x691F86


### PR DESCRIPTION
- https://github.com/IntelOrca/openre/pull/60

## Changes

- Implement `hud_inventory_mix_item`
- Move `set_inventory_item_quantity` and `set_inventory_item` functions from player.cpp to hud.cpp
- Fix `set_inventory_item_quantity`: bug while reloading flamethrower and sub machine gun
- Add `check_input` function utility