### PR TITLE
Implement player step down animation

### DIFF
--- a/address_map.txt
+++ b/address_map.txt
@@ -246,7 +246,7 @@ declare     sce_free3               u16
 declare     spl_flg                 u16
 declare     parts0_pos_y            u16
 declare     pT_xz                   u32
-declare     pOn_om                  s32
+declare     pOn_om                  u32
 declare     nOba                    s32
 declare     attw_timer              u8
 declare     attw_seq_no             u8
@@ -651,6 +651,7 @@ declare     enemy_init_map          void*[96]               0x0098A154
 declare     enemy_init_table        void*[192]              0x0098A2D4
 declare     enemy_init_entries      EnemyInitEntry[2]       0x0098A614
 declare     pOm                     ObjectEntity[32]        0x0098A61C
+declare     obj_ptr                 ObjectEntity*           0x0098E51C
 declare     aot_count               u8                      0x0098E528
 declare     byte_98E541             u8                      0x0098E541
 declare     dword_98E790            u32                     0x0098E790

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -39,4 +39,26 @@ namespace openre
     {
         interop::call<void, Entity*, int16_t>(0x004B21D0, entity, d);
     }
+
+    uint8_t compute_nfloor(int32_t posY)
+    {
+        auto mul = static_cast<int64_t>(0x6E5D4C3B) * posY;
+        auto hi32 = static_cast<int32_t>(mul >> 32);
+        auto diff = hi32 - posY;
+        auto floorDiv = diff >> 10;
+        auto correction = (diff >> 31) & 1;
+        return floorDiv + correction;
+    }
+
+    // 0x004CD610
+    void oma_set_ofs(ObjectEntity* object)
+    {
+        interop::call<void, ObjectEntity*>(0x004CD610, object);
+    }
+
+    // 0x004CEEF0
+    int omd_in_check(Vec32* vec, ObjectEntity* object, int a2, int a3)
+    {
+        return interop::call<int, Vec32*, ObjectEntity*, int, int>(0x004CEEF0, vec, object, a2, a3);
+    }
 }

--- a/src/entity.h
+++ b/src/entity.h
@@ -10,4 +10,7 @@ namespace openre
     int joint_move(Entity* player, Emr* pKanPtr, Edd* pSeqPtr, int lateFlag);
     int32_t goto00_ck(Entity* entity, int32_t x, int32_t z, int32_t dist);
     void add_speed_xz(Entity* entity, int16_t d);
+    uint8_t compute_nfloor(int32_t posY);
+    void oma_set_ofs(ObjectEntity* object);
+    int omd_in_check(Vec32* vec, ObjectEntity* object, int a2, int a3);
 }

--- a/src/input.h
+++ b/src/input.h
@@ -24,7 +24,7 @@ namespace openre::input
         KEY_TYPE_LEFT = 2,
         KEY_TYPE_RIGHT = 8,
         KEY_TYPE_ROTATE = 10,
-        KEY_TYPE_128 = 128,
+        KEY_TYPE_ACTION = 128,
         KEY_TYPE_AIM = 256,
         KEY_TYPE_RUN_AND_CANCEL = 512,
     };

--- a/src/openre.h
+++ b/src/openre.h
@@ -109,7 +109,7 @@ namespace openre
         FG_STATUS_BONUS = 6,
         FG_STATUS_GAMEPLAY = 8,
         FG_STATUS_9 = 9,
-        FG_STATUS_10 = 10,
+        FG_STATUS_INTERACT = 10,
         FG_STATUS_11 = 11,
         FG_STATUS_12 = 12,
         FG_STATUS_13 = 13,

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -685,9 +685,9 @@ namespace openre::player
                 set_routine(Routine::QUICKTURN);
                 return;
             }
-            if ((key_trg & input::KEY_TYPE_128) != 0)
+            if ((key_trg & input::KEY_TYPE_ACTION) != 0)
             {
-                set_flag(FlagGroup::Status, FG_STATUS_10, true);
+                set_flag(FlagGroup::Status, FG_STATUS_INTERACT, true);
             }
             if (key & input::KEY_TYPE_AIM && player->type & 0xFFF)
             {
@@ -783,7 +783,7 @@ namespace openre::player
         {
             set_routine(Routine::PUSH_OBJECT);
         }
-        if ((key & input::KEY_TYPE_128) == 0 && (key_trg & input::KEY_TYPE_128) == 0)
+        if ((key & input::KEY_TYPE_ACTION) == 0 && (key_trg & input::KEY_TYPE_ACTION) == 0)
         {
             goto LABEL_31;
         }
@@ -794,9 +794,9 @@ namespace openre::player
         }
         if (oma_pl_updown_ck(player->id + 4) == 0)
         {
-            if (key_trg & input::KEY_TYPE_128)
+            if (key_trg & input::KEY_TYPE_ACTION)
             {
-                set_flag(FlagGroup::Status, FG_STATUS_10, true);
+                set_flag(FlagGroup::Status, FG_STATUS_INTERACT, true);
             }
         LABEL_31:
             if (key & input::KEY_TYPE_AIM && player->type & 0xFFF)
@@ -821,7 +821,7 @@ namespace openre::player
         {
             set_routine(Routine::FORWARD);
         }
-        if (((key & input::KEY_TYPE_128) == 0) && ((key_trg & input::KEY_TYPE_128) == 0))
+        if (((key & input::KEY_TYPE_ACTION) == 0) && ((key_trg & input::KEY_TYPE_ACTION) == 0))
         {
             goto LABEL_25;
         }
@@ -831,9 +831,9 @@ namespace openre::player
         }
         if (oma_pl_updown_ck(player->id + 4) == 0)
         {
-            if (key_trg & input::KEY_TYPE_128)
+            if (key_trg & input::KEY_TYPE_ACTION)
             {
-                set_flag(FlagGroup::Status, FG_STATUS_10, true);
+                set_flag(FlagGroup::Status, FG_STATUS_INTERACT, true);
             }
 
         LABEL_25:
@@ -869,7 +869,7 @@ namespace openre::player
         {
             player->cdir.y -= yAxisRotationSpeed[player->d_life_u];
         }
-        if (key & input::KEY_TYPE_128 || key_trg & input::KEY_TYPE_128)
+        if (key & input::KEY_TYPE_ACTION || key_trg & input::KEY_TYPE_ACTION)
         {
             if (player->Sca_info & 0x100000)
             {
@@ -880,9 +880,9 @@ namespace openre::player
             {
                 return;
             }
-            if (key_trg & input::KEY_TYPE_128)
+            if (key_trg & input::KEY_TYPE_ACTION)
             {
-                set_flag(FlagGroup::Status, FG_STATUS_10, true);
+                set_flag(FlagGroup::Status, FG_STATUS_INTERACT, true);
             }
         }
         if (key & input::KEY_TYPE_AIM && player->type & 0xFFF)
@@ -916,9 +916,9 @@ namespace openre::player
         {
             set_routine(Routine::ROTATE);
         }
-        if (key_trg & input::KEY_TYPE_128)
+        if (key_trg & input::KEY_TYPE_ACTION)
         {
-            set_flag(FlagGroup::Status, FG_STATUS_10, true);
+            set_flag(FlagGroup::Status, FG_STATUS_INTERACT, true);
             if (player->Sca_info & 0x100000)
             {
                 sca_hit_stairs(player, 450, gGameTable.dword_695E7C);
@@ -1204,7 +1204,7 @@ namespace openre::player
                     player->cdir.y -= yAxisRotationSpeed[player->d_life_u];
                 }
             }
-            if (key & input::KEY_TYPE_128 || key_trg & input::KEY_TYPE_128)
+            if (key & input::KEY_TYPE_ACTION || key_trg & input::KEY_TYPE_ACTION)
             {
                 if (player->Sca_info & 0x100000)
                 {
@@ -1215,9 +1215,9 @@ namespace openre::player
                 {
                     return;
                 }
-                if (key_trg & input::KEY_TYPE_128)
+                if (key_trg & input::KEY_TYPE_ACTION)
                 {
-                    set_flag(FlagGroup::Status, FG_STATUS_10, true);
+                    set_flag(FlagGroup::Status, FG_STATUS_INTERACT, true);
                 }
             }
             if (key & input::KEY_TYPE_AIM && player->type & 0xFFF)

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -971,7 +971,7 @@ namespace openre::player
             player->mplay_flg = 0;
             player->spd.x = 1000;
             player->m.pos.y += 550;
-            player->timer0 = 5; // Needed ?
+            player->timer0 = 5;
             if (player->id == PLD_SHERRY)
             {
                 player->spd.x = 600;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -898,7 +898,7 @@ namespace openre::player
         {
             set_routine(Routine::ROTATE);
         }
-        if (key_trg & 0x80)
+        if (key_trg & input::KEY_TYPE_128)
         {
             set_flag(FlagGroup::Status, FG_STATUS_10, true);
             if (player->Sca_info & 0x100000)

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -152,7 +152,6 @@ namespace openre::player
         case Routine::QUICKTURN:
             gPlayerEntity.routine_0 = 1;
             gPlayerEntity.routine_1 = 0xC;
-
             break;
         case Routine::PUSH_OBJECT:
             gPlayerEntity.routine_0 = 1;
@@ -874,6 +873,48 @@ namespace openre::player
         }
     }
 
+    // 0x004DB930
+    void pl_br_step_down(PlayerEntity* player, uint32_t key, uint32_t key_trg)
+    {
+        if (player->routine_3 <= 4)
+        {
+            // Play step down animation
+            return;
+        }
+        // End step down animation
+        if (key & input::KEY_TYPE_FORWARD)
+        {
+            set_routine(Routine::FORWARD);
+            if (key & input::KEY_TYPE_RUN_AND_CANCEL)
+            {
+                set_routine(Routine::RUN_FORWARD);
+            }
+        }
+        if (key & input::KEY_TYPE_BACKWARD)
+        {
+            set_routine(Routine::BACKWARD);
+        }
+        if (key & input::KEY_TYPE_ROTATE)
+        {
+            set_routine(Routine::ROTATE);
+        }
+        if (key_trg & 0x80)
+        {
+            set_flag(FlagGroup::Status, FG_STATUS_10, true);
+            if (player->Sca_info & 0x100000)
+            {
+                sca_hit_stairs(player, 450, gGameTable.dword_695E7C);
+            }
+        }
+        if ((key & input::KEY_TYPE_AIM) && (player->type & 0xFFF))
+        {
+            set_routine(Routine::AIM);
+        }
+    }
+
+    // 0x004DB9D0
+    void pl_mv_step_down(PlayerEntity* player, uint32_t key, uint32_t key_trg) {}
+
     // 0x004DBD90
     void pl_br_push_object(PlayerEntity* player, uint32_t key, uint32_t key_trg)
     {
@@ -1052,6 +1093,7 @@ namespace openre::player
         br_tbl[2] = pl_br_run_forward;
         br_tbl[3] = pl_br_backward;
         br_tbl[4] = pl_br_rotate;
+        br_tbl[9] = pl_br_step_down;
         br_tbl[10] = pl_br_push_object;
         br_tbl[12] = pl_br_quickturn;
         // set mv hooks

--- a/src/re2.h
+++ b/src/re2.h
@@ -300,7 +300,7 @@ struct ActorEntity : Entity
     uint16_t spl_flg;                   // 0x01DC
     uint16_t parts0_pos_y;              // 0x01DE
     uint32_t pT_xz;                     // 0x01E0
-    int32_t pOn_om;                     // 0x01E4
+    uint32_t pOn_om;                    // 0x01E4
     int32_t nOba;                       // 0x01E8
     uint8_t attw_timer;                 // 0x01EC
     uint8_t attw_seq_no;                // 0x01ED
@@ -872,7 +872,8 @@ struct GameTable
     uint8_t pad_98A5D4[64];             // 0x98A5D4
     EnemyInitEntry enemy_init_entries[2];// 0x98A614
     ObjectEntity pOm[32];               // 0x98A61C
-    uint8_t pad_98E51C[12];             // 0x98E51C
+    ObjectEntity* obj_ptr;              // 0x98E51C
+    uint8_t pad_98E520[8];              // 0x98E520
     uint8_t aot_count;                  // 0x98E528
     uint8_t pad_98E529[24];             // 0x98E529
     uint8_t byte_98E541;                // 0x98E541


### PR DESCRIPTION
## Changes

- Implement pl_mv_step_down `0x004DB9D0`
- Implement pl_br_step_down `0x004DB930`
- Rename input enum key `KEY_TYPE_128` to `KEY_TYPE_ACTION`
- Rename fg_status enum key `FG_STATUS_10` to `FG_STATUS_INTERACT`
- Add new utiliy function `compute_nfloor`. I think this function is useful because there are multiple places where this calculation has to be done. Some examples:
https://github.com/IntelOrca/openre/blob/dd596782c0b41177e0cba6359ff8e8af3f35f956/src/em_spider.cpp#L393 
https://github.com/IntelOrca/openre/blob/dd596782c0b41177e0cba6359ff8e8af3f35f956/src/title.cpp#L302
(Other one is also in the incoming `set_room` pull request)