### PR TITLE
Fix: Use correct sound for game intro

### DIFF
--- a/src/title.cpp
+++ b/src/title.cpp
@@ -165,7 +165,7 @@ namespace openre::title
         }
         case 4:
         {
-            snd_load_core(0x10, 0);
+            snd_load_core(0x11, 0);
             if (ctcb.var_13 == 0)
             {
                 ctcb.var_09 = 5;


### PR DESCRIPTION
## Description

The sound that plays when you start the game should said: "Resident Evil 2", currently is using the Japanese title "Biohazard 2".  This bug was introduced in the following pr: https://github.com/IntelOrca/openre/pull/78 
When I did the decompilation, I was probably working without headphones, so I didn’t notice the error at the time. Interestingly, the assembly code is using sound id`0x10`, which corresponds to the Japanese version. The correct sound ID for the European/American version is `0x11`.